### PR TITLE
Add config for excluding client-side mods from comparison

### DIFF
--- a/src/main/java/xyz/starmun/actuallycompatible/config/ActuallyCompatibleConfig.java
+++ b/src/main/java/xyz/starmun/actuallycompatible/config/ActuallyCompatibleConfig.java
@@ -1,9 +1,15 @@
 package xyz.starmun.actuallycompatible.config;
 
 import net.minecraftforge.common.ForgeConfigSpec;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 public class ActuallyCompatibleConfig {
     public static final ForgeConfigSpec.IntValue newPacketBufferSize;
+    public static final ForgeConfigSpec.ConfigValue<List<? extends String>> clientIgnoredMods;
     public static final ForgeConfigSpec.Builder builder = new ForgeConfigSpec.Builder();
     public static final ForgeConfigSpec SPEC;
     static {
@@ -13,6 +19,13 @@ public class ActuallyCompatibleConfig {
                 .translation("text.actuallycompatible.config.new_packet_buffer_size")
                 .defineInRange("newPaketBufferSize",defaultPacketBufferSize,32767, Integer.MAX_VALUE);
         builder.pop();
+
+        builder.push("Ignored Mods");
+        clientIgnoredMods = builder.comment("Client-side mod IDs that will be ignored if not present on the server.")
+                .defineListAllowEmpty(Collections.singletonList("clientIgnoredMods"), ArrayList::new,
+                        s -> s instanceof String && StringUtils.isAsciiPrintable((String) s));
+        builder.pop();
+
         SPEC = builder.build();
     }
 }

--- a/src/main/java/xyz/starmun/actuallycompatible/config/ActuallyCompatibleConfig.java
+++ b/src/main/java/xyz/starmun/actuallycompatible/config/ActuallyCompatibleConfig.java
@@ -10,6 +10,7 @@ import java.util.List;
 public class ActuallyCompatibleConfig {
     public static final ForgeConfigSpec.IntValue newPacketBufferSize;
     public static final ForgeConfigSpec.ConfigValue<List<? extends String>> clientIgnoredMods;
+    public static final ForgeConfigSpec.ConfigValue<List<? extends String>> serverIgnoredMods;
     public static final ForgeConfigSpec.Builder builder = new ForgeConfigSpec.Builder();
     public static final ForgeConfigSpec SPEC;
     static {
@@ -23,6 +24,9 @@ public class ActuallyCompatibleConfig {
         builder.push("Ignored Mods");
         clientIgnoredMods = builder.comment("Client-side mod IDs that will be ignored if not present on the server.")
                 .defineListAllowEmpty(Collections.singletonList("clientIgnoredMods"), ArrayList::new,
+                        s -> s instanceof String && StringUtils.isAsciiPrintable((String) s));
+        serverIgnoredMods = builder.comment("Server-side mod IDs that will not be sent to the client.")
+                .defineListAllowEmpty(Collections.singletonList("serverIgnoredMods"), ArrayList::new,
                         s -> s instanceof String && StringUtils.isAsciiPrintable((String) s));
         builder.pop();
 

--- a/src/main/java/xyz/starmun/actuallycompatible/mixin/FMLStatusPingMixin.java
+++ b/src/main/java/xyz/starmun/actuallycompatible/mixin/FMLStatusPingMixin.java
@@ -11,6 +11,7 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import xyz.starmun.actuallycompatible.config.ActuallyCompatibleConfig;
 import xyz.starmun.actuallycompatible.contracts.IFMLStatPingExtensions;
 import java.util.Map;
 
@@ -63,7 +64,9 @@ public class FMLStatusPingMixin implements IFMLStatPingExtensions {
             obj.add("channels", channels);
 
             JsonArray modTestValues = new JsonArray();
-            ((IFMLStatPingExtensions)forgeData).getMods().entrySet().stream().limit(MOD_TRUNCATE_LIMIT).forEach(entry -> {
+            ((IFMLStatPingExtensions)forgeData).getMods().entrySet().stream()
+                    .filter(entry -> !ActuallyCompatibleConfig.serverIgnoredMods.get().contains(entry.getKey()))
+                    .limit(MOD_TRUNCATE_LIMIT).forEach(entry -> {
                 String modId = entry.getKey();
                 String value = entry.getValue();
                 JsonObject mi = new JsonObject();

--- a/src/main/java/xyz/starmun/actuallycompatible/mixin/ModContainerMixin.java
+++ b/src/main/java/xyz/starmun/actuallycompatible/mixin/ModContainerMixin.java
@@ -5,14 +5,12 @@ import net.minecraftforge.fml.ModContainer;
 import org.apache.commons.lang3.tuple.Pair;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import xyz.starmun.actuallycompatible.config.ActuallyCompatibleConfig;
 
-import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiPredicate;
 import java.util.function.Supplier;
@@ -23,10 +21,6 @@ abstract class ModContainerMixin {
     @Final
     @Shadow
     protected String modId;
-
-    @Final
-    @Shadow
-    protected Map<ExtensionPoint, Supplier<?>> extensionPoints;
 
     @SuppressWarnings("unchecked")
     @Inject(method = "getCustomExtension",at = @At("HEAD"), cancellable = true)

--- a/src/main/java/xyz/starmun/actuallycompatible/mixin/ModContainerMixin.java
+++ b/src/main/java/xyz/starmun/actuallycompatible/mixin/ModContainerMixin.java
@@ -1,0 +1,39 @@
+package xyz.starmun.actuallycompatible.mixin;
+
+import net.minecraftforge.fml.ExtensionPoint;
+import net.minecraftforge.fml.ModContainer;
+import org.apache.commons.lang3.tuple.Pair;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import xyz.starmun.actuallycompatible.config.ActuallyCompatibleConfig;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.BiPredicate;
+import java.util.function.Supplier;
+
+@Mixin(value = ModContainer.class, remap = false)
+abstract class ModContainerMixin {
+
+    @Final
+    @Shadow
+    protected String modId;
+
+    @Final
+    @Shadow
+    protected Map<ExtensionPoint, Supplier<?>> extensionPoints;
+
+    @SuppressWarnings("unchecked")
+    @Inject(method = "getCustomExtension",at = @At("HEAD"), cancellable = true)
+    public <T> void getCustomExtension(ExtensionPoint<T> point, CallbackInfoReturnable<Optional<T>> callback) {
+        if (ExtensionPoint.DISPLAYTEST.equals(point) && ActuallyCompatibleConfig.clientIgnoredMods.get().contains(modId)) {
+            // mark mod as compatible even when not present on the server
+            callback.setReturnValue(Optional.of((T)Pair.<Supplier<String>, BiPredicate<String, Boolean>>of(() -> "", (a, b) -> true)));
+        }
+    }
+}

--- a/src/main/resources/actuallycompatible.mixins.json
+++ b/src/main/resources/actuallycompatible.mixins.json
@@ -10,6 +10,7 @@
     "PacketBufferEncoderMixin"
   ],
   "client": [
+    "ModContainerMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
As mentioned in the CurseForge comments, this adds a config to allow modpack creators to mark mods as single side compatible, even if they do not have DISPLAYTEST configured correctly.